### PR TITLE
Fix #18: When password is entered wrong instead of telling so, the ap…

### DIFF
--- a/src/main/java/org/molgenis/downloader/api/MolgenisClient.java
+++ b/src/main/java/org/molgenis/downloader/api/MolgenisClient.java
@@ -6,10 +6,12 @@ import java.net.URISyntaxException;
 import org.molgenis.downloader.api.metadata.Entity;
 import org.molgenis.downloader.api.metadata.MolgenisVersion;
 
+import javax.naming.AuthenticationException;
+
 
 public interface MolgenisClient extends AutoCloseable {
 
-    void login(final String username, final String password);
+    void login(final String username, final String password) throws AuthenticationException;
 
     boolean logout();
     

--- a/src/main/java/org/molgenis/downloader/client/MolgenisRestApiClient.java
+++ b/src/main/java/org/molgenis/downloader/client/MolgenisRestApiClient.java
@@ -21,6 +21,7 @@ import org.molgenis.downloader.api.metadata.Entity;
 import org.molgenis.downloader.api.metadata.MolgenisVersion;
 import org.molgenis.downloader.util.ConsoleWriter;
 
+import javax.naming.AuthenticationException;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -50,8 +51,7 @@ public class MolgenisRestApiClient implements MolgenisClient
 	}
 
 	@Override
-	public final void login(final String username, final String password)
-	{
+	public final void login(final String username, final String password) throws AuthenticationException {
 		final JSONObject login = new JSONObject();
 		login.put("username", username);
 		login.put("password", password);
@@ -73,6 +73,9 @@ public class MolgenisRestApiClient implements MolgenisClient
 		catch (final JSONException | IOException | URISyntaxException ex)
 		{
 			writeToConsole("An error occurred while logging in:\n", ex);
+		}
+		if(token == null){
+			throw new AuthenticationException("Username or password is incorrect");
 		}
 	}
 


### PR DESCRIPTION
…p tells that the meta cannot be found