### PR TITLE
Fix #27 #35 #39 #40

### DIFF
--- a/src/main/java/org/molgenis/downloader/Downloader.java
+++ b/src/main/java/org/molgenis/downloader/Downloader.java
@@ -72,7 +72,7 @@ public class Downloader
 		parser.acceptsAll(asList("o", OVERWRITE), "Overwrite the exisiting file if it exists.");
 		parser.acceptsAll(asList("u", URL), "URL of the MOLGENIS instance").withRequiredArg().ofType(String.class)
 				.required();
-		parser.acceptsAll(asList("d", DATA_ONLY), "Write only the data for the entities to the output file.");
+		parser.acceptsAll(asList("D", DATA_ONLY), "Write only the data for the entities to the output file.");
 		parser.acceptsAll(asList("a", ACCOUNT), "MOLGENIS username to login with to download the data.")
 				.withRequiredArg().ofType(String.class);
 		parser.acceptsAll(asList("p", PASSWORD), "Password for the MOLGENIS user to login").withRequiredArg()

--- a/src/main/java/org/molgenis/downloader/Downloader.java
+++ b/src/main/java/org/molgenis/downloader/Downloader.java
@@ -4,6 +4,9 @@ import joptsimple.OptionException;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.params.HttpConnectionParams;
+import org.apache.http.params.HttpParams;
 import org.molgenis.downloader.api.MolgenisClient;
 import org.molgenis.downloader.api.metadata.MolgenisVersion;
 import org.molgenis.downloader.client.HttpClientFactory;
@@ -22,7 +25,7 @@ import static org.molgenis.downloader.util.ConsoleWriter.writeToConsole;
 public class Downloader
 {
 	private static final String URL = "url";
-	private static final String META = "meta";
+	private static final String DATA_ONLY = "dataOnly";
 	private static final String ACCOUNT = "account";
 	private static final String PASSWORD = "password";
 	private static final String INSECURE_SSL = "insecureSSL";
@@ -32,6 +35,8 @@ public class Downloader
 	private static final String PAGESIZE = "pageSize";
 	private static final String DEBUG = "debug";
 	private static final String VERSION = "version";
+	private static final String SOCKET_TIMEOUT = "timeout";
+	private static final Integer DEFAULT_SOCKET_TIMEOUT = 60;
 
 	public static boolean debug;
 
@@ -67,9 +72,9 @@ public class Downloader
 		parser.acceptsAll(asList("o", OVERWRITE), "Overwrite the exisiting file if it exists.");
 		parser.acceptsAll(asList("u", URL), "URL of the MOLGENIS instance").withRequiredArg().ofType(String.class)
 				.required();
-		parser.acceptsAll(asList("m", META), "Write the metadata for the entities to the output file.");
+		parser.acceptsAll(asList("d", DATA_ONLY), "Write only the data for the entities to the output file.");
 		parser.acceptsAll(asList("a", ACCOUNT), "MOLGENIS username to login with to download the data.")
-				.withRequiredArg().ofType(String.class).required();
+				.withRequiredArg().ofType(String.class);
 		parser.acceptsAll(asList("p", PASSWORD), "Password for the MOLGENIS user to login").withRequiredArg()
 				.ofType(String.class);
 		parser.acceptsAll(asList("i", INSECURE_SSL), "Ignore SSL certicate chain errors and hostname mismatches.");
@@ -78,6 +83,8 @@ public class Downloader
 		parser.acceptsAll(asList("d", DEBUG), "print debug logging to console");
 		parser.acceptsAll(asList("v", VERSION), "Optional parameter to override the result form '/api/v2/version/'").withRequiredArg()
 				.ofType(String.class);
+		parser.acceptsAll(asList("t", SOCKET_TIMEOUT), "Optional parameter to configure the socket timeout in seconds, default value is 60").withRequiredArg()
+			  .ofType(Integer.class);
 
 		return parser;
 	}
@@ -89,22 +96,20 @@ public class Downloader
 		List<String> entities = (List<String>) options.valuesOf(ARGUMENTS);
 		URI url = options.hasArgument(URL) ? new URI((String) options.valueOf(URL)) : null;
 		Integer pageSize = options.hasArgument(PAGESIZE) ? (Integer) options.valueOf(PAGESIZE) : null;
-		boolean includeMetaData = options.has(META);
+		boolean includeMetaData = !options.has(DATA_ONLY);
 		boolean insecureSSL = options.has(INSECURE_SSL);
 		String username = (String) options.valueOf(ACCOUNT);
 		String password = (String) options.valueOf(PASSWORD);
 		boolean overwrite = options.has(OVERWRITE);
 		String versionString = (String) options.valueOf(VERSION);
+		Integer socketTimeout = options.hasArgument(SOCKET_TIMEOUT) ? (Integer) options.valueOf(SOCKET_TIMEOUT) : DEFAULT_SOCKET_TIMEOUT;
 
 		debug = options.has(DEBUG);
 
 		final HttpClient client = HttpClientFactory.create(insecureSSL);
 
-
-
 		try (final MolgenisClient molgenis = new MolgenisRestApiClient(client, url))
 		{
-
 			if (username != null)
 			{
 				if (password == null)
@@ -121,7 +126,7 @@ public class Downloader
 						return;
 					}
 				}
-				molgenis.login(username, password);
+				molgenis.login(username, password, socketTimeout);
 			}
 			try (final EMXClient emxClient = new EMXClient(molgenis))
 			{

--- a/src/main/java/org/molgenis/downloader/api/MolgenisClient.java
+++ b/src/main/java/org/molgenis/downloader/api/MolgenisClient.java
@@ -11,7 +11,7 @@ import javax.naming.AuthenticationException;
 
 public interface MolgenisClient extends AutoCloseable {
 
-    void login(final String username, final String password) throws AuthenticationException;
+    void login(final String username, final String password, final Integer timeout) throws AuthenticationException;
 
     boolean logout();
     

--- a/src/main/java/org/molgenis/downloader/client/MolgenisRestApiClient.java
+++ b/src/main/java/org/molgenis/downloader/client/MolgenisRestApiClient.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.ParseException;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
@@ -51,7 +52,7 @@ public class MolgenisRestApiClient implements MolgenisClient
 	}
 
 	@Override
-	public final void login(final String username, final String password) throws AuthenticationException {
+	public final void login(final String username, final String password, final Integer socketTimeout) throws AuthenticationException {
 		final JSONObject login = new JSONObject();
 		login.put("username", username);
 		login.put("password", password);
@@ -59,9 +60,13 @@ public class MolgenisRestApiClient implements MolgenisClient
 		token = null;
 		try
 		{
+			RequestConfig.Builder requestConfigBuilder = RequestConfig.custom();
+			requestConfigBuilder.setSocketTimeout(1000 * socketTimeout);
+
 			final HttpPost request = new HttpPost(new URI(uri + "/api/v1/login"));
 			request.setHeader("Content-Type", "application/json");
 			request.setEntity(new StringEntity(login.toString()));
+			request.setConfig(requestConfigBuilder.build());
 
 			final HttpResponse result = client.execute(request);
 			if (result.getStatusLine().getStatusCode() == 200)

--- a/src/main/java/org/molgenis/downloader/emx/serializers/EMXAttributeSerializer.java
+++ b/src/main/java/org/molgenis/downloader/emx/serializers/EMXAttributeSerializer.java
@@ -77,7 +77,7 @@ public class EMXAttributeSerializer implements EntitySerializer<Attribute> {
         result.add(att.getTags().stream().map(Tag::getId).collect(joining(",")));
         result.add(att.getDescription());
         if (fields().contains(MAPPED_BY)) {
-            result.add(Optional.ofNullable(att.getMappedBy()).map(Attribute::getEntityFullname).orElse(""));
+            result.add(att.getMappedBy()!=null?att.getMappedBy().getName():"");
         }
         languages.forEach(language -> {
             result.add(att.getDescriptions().get(language));

--- a/src/main/java/org/molgenis/downloader/emx/serializers/v3/EMXAttributeSerializerV3.java
+++ b/src/main/java/org/molgenis/downloader/emx/serializers/v3/EMXAttributeSerializerV3.java
@@ -72,7 +72,7 @@ public class EMXAttributeSerializerV3 implements EntitySerializer<Attribute> {
         result.add(att.getTags().stream().map(Tag::getId).collect(joining(",")));
         result.add(att.getDescription());
         if (fields().contains(MAPPED_BY)) {
-            result.add(Optional.ofNullable(att.getMappedBy()).map(Attribute::getEntityFullname).orElse(""));
+            result.add(att.getMappedBy()!=null?att.getMappedBy().getName():"");
         }
         languages.forEach(language -> {
             result.add(att.getDescriptions().get(language));

--- a/src/test/java/org/molgenis/downloader/client/MolgenisRestApiClientTest.java
+++ b/src/test/java/org/molgenis/downloader/client/MolgenisRestApiClientTest.java
@@ -23,8 +23,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.AssertJUnit.assertEquals;
 
-import com.google.common.io.Resources;
-
 public class MolgenisRestApiClientTest
 {
 	@Test


### PR DESCRIPTION
#40 Downloading very big datasets (> 60.000 rows) results in timeout bug
Timeout is now configurable (in seconds) with the -t parameter

#39 MappedBy downloads as entity instead of attribute bug
Fixed

#35 Download with metadata should be the default enhancement
-m option is replaced with -d (data only).

#27 I have to enter required admin password even if I want to download public data.
Fixed: password is now only required if an account is specified, account is no longer a required option